### PR TITLE
Homepage fix

### DIFF
--- a/app.py
+++ b/app.py
@@ -230,11 +230,11 @@ def profile():
 
     user = User.query.get_or_404(g.user.id)
     
-    form = UserEditForm(obj=user)
+    form = UserEditForm()
     
     if form.validate_on_submit():
         # query the current logged in user
-
+        
         # authentice the user
         valid_user = User.authenticate(user.username, form.password.data)
 
@@ -342,8 +342,10 @@ def homepage():
     """
 
     if g.user:
+        # following = [f.id for f in g.user.following]
         messages = (Message
                     .query
+                    # .filter((g.user.following.all()))
                     .order_by(Message.timestamp.desc())
                     .limit(100)
                     .all())

--- a/app.py
+++ b/app.py
@@ -342,14 +342,18 @@ def homepage():
     """
 
     if g.user:
-        # following = [f.id for f in g.user.following]
+        # create a list of all ids that our user follows
+        following = [f.id for f in g.user.following]
+        # append our user's id as well into this list
+        following.append(g.user.id)
+        # query all messages that match the ids in our following list
         messages = (Message
                     .query
-                    # .filter((g.user.following.all()))
+                    .filter(Message.user_id.in_(following))
                     .order_by(Message.timestamp.desc())
                     .limit(100)
                     .all())
-
+        
         return render_template('home.html', messages=messages)
 
     else:

--- a/readme.md
+++ b/readme.md
@@ -6,3 +6,9 @@ Create an account, add a user, edit profile, follow people, and more.
 ## Known Bugs
 
 -   unittest for edit profile is not working properly
+
+## Roadmap
+
+-   implement coverage testing:
+    -   https://www.rithmschool.com/courses/intermediate-flask/testing-flask-json-apis
+    -   https://coverage.readthedocs.io/en/6.3.3/

--- a/test_user_views.py
+++ b/test_user_views.py
@@ -280,7 +280,7 @@ class UserViewTestCase(TestCase):
 
     def test_followers_on_followers_page(self):
         """
-        Test that a follower appears on the a user's follower's page.
+        Test that a follower appears on the user's follower's page.
         """
 
         # Since we need to change the session to mimic logging in,
@@ -520,3 +520,104 @@ class UserViewTestCase(TestCase):
 
             # check for flashed 'Incorrect password' message
             self.assertIn("Incorrect password", html)
+
+    def test_show_messages_from_users_that_curr_users_follows(self):
+        """
+        Show only messages from users that the user follows, plus curr user's messages.
+        """
+        
+        # create a test message for our curr user, the user they follow, and a follower
+        following_test_message = Message(
+            text = "testing a new message from a person we follow"
+        )
+        follower_test_message = Message(
+            text = "testing a new message from a person that follows curr user. this should not appear."
+        )
+        curr_test_message = Message(
+            text = "testing our curr users new message"
+        )
+        
+        # append the messages to each user
+        self.followinguser.messages.append(following_test_message)
+        self.followeruser.messages.append(follower_test_message)
+        self.testuser.messages.append(curr_test_message)
+
+        # Add the followinguser to the testuser's list of followers
+        # just so that we can attach this User object to session
+        self.testuser.following.append(self.followinguser)
+        self.followeruser.following.append(self.testuser)
+        db.session.commit()
+        
+        # Since we need to change the session to mimic logging in,
+        # we need to use the changing-session trick:
+
+        with self.client as c:
+            with c.session_transaction() as sess:
+                sess[CURR_USER_KEY] = self.testuser.id
+            
+            # We have to query the users due to a restriction of Session's lazy load operation
+            curr_user = User.query.get(sess[CURR_USER_KEY])
+
+            resp = c.get('/')
+
+            html = resp.get_data(as_text=True)
+
+            self.assertIn(curr_user.following[0].messages[0].text, html)
+            self.assertIn(curr_user.messages[0].text, html)
+
+            # make sure we don't see follower's messages in our curr user feed
+            # since we don't follow them
+            self.assertNotIn(curr_user.followers[0].messages[0].text, html)
+
+    def test_show_signup_screen_for_anon_users(self):
+        """
+        Show signup screen when anon user visits "/".
+        """
+        
+        # Since we need to change the session to mimic logging in,
+        # we need to use the changing-session trick:
+
+        with self.client as c:
+            
+            resp = c.get('/')
+
+            html = resp.get_data(as_text=True)
+
+            # make sure we don't see follower's messages in our curr user feed
+            # since we don't follow them
+            self.assertIn("New to Warbler?", html)
+
+    def test_show_100_messages_max_for_curr_user(self):
+        """
+        Show only 100 messages max for a curr user.
+        """
+        
+        i = 0
+
+        while (i < 200):
+            i += 1
+            test_message = Message(
+                text = f'message number {i}'
+            )
+            self.testuser.messages.append(test_message)
+        
+        db.session.commit()
+
+        # Since we need to change the session to mimic logging in,
+        # we need to use the changing-session trick:
+
+        with self.client as c:
+            with c.session_transaction() as sess:
+                sess[CURR_USER_KEY] = self.testuser.id
+            
+            # We have to query the users due to a restriction of Session's lazy load operation
+            curr_user = User.query.get(sess[CURR_USER_KEY])
+
+            resp = c.get('/')
+
+            html = resp.get_data(as_text=True)
+
+            self.assertIn(curr_user.messages[0].text, html)
+            self.assertIn(curr_user.messages[50].text, html)
+            self.assertNotIn(curr_user.messages[150].text, html)
+            self.assertNotIn(curr_user.messages[199].text, html)


### PR DESCRIPTION
### User.authentication() unittest bug

- Fixed the previous testing issue we had with validating the user.auth test.
- The solution inside the unittest is to pass the password in as a literal string vs. passing the reference to it.
- Tested and verified that this unittest works.

### Homepage fixes

- Homepage now shows messages of only users that the curr user follows + curr user's own messages.
- Homepage now limits messages to 100 max, with most recent at the top.
- Added unittests for these changes as well
